### PR TITLE
Fix default warmup handler WSGI designation

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -22,7 +22,7 @@ libraries:
 
 handlers:
 - url: /_ah/warmup
-  script: warmup.application
+  script: routes.application
 
 - url: /(robots\.txt|favicon\.ico)
   static_files: static/\1


### PR DESCRIPTION
The template creates a broken warmup handler. This fixes it.
